### PR TITLE
changes the login response to json

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,11 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.15.4</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/harneet/ucal/physicianAssistantService/controller/AuthController.java
+++ b/src/main/java/com/harneet/ucal/physicianAssistantService/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.harneet.ucal.physicianAssistantService.controller;
 
 import com.harneet.ucal.physicianAssistantService.model.User;
 import com.harneet.ucal.physicianAssistantService.service.UserService;
+import com.harneet.ucal.physicianAssistantService.util.AuthToken;
 import com.harneet.ucal.physicianAssistantService.util.JwtUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -33,7 +34,7 @@ public class AuthController {
     private PasswordEncoder passwordEncoder;
 
     @PostMapping("/login")
-    public String login(@RequestBody User user) throws Exception {
+    public AuthToken login(@RequestBody User user) throws Exception {
         try {
             authenticationManager.authenticate(
                     new UsernamePasswordAuthenticationToken(user.getEmail(), user.getPassword())

--- a/src/main/java/com/harneet/ucal/physicianAssistantService/util/AuthToken.java
+++ b/src/main/java/com/harneet/ucal/physicianAssistantService/util/AuthToken.java
@@ -1,0 +1,16 @@
+package com.harneet.ucal.physicianAssistantService.util;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Date;
+
+public class AuthToken {
+    @JsonProperty
+    private final String token;
+    @JsonProperty
+    private final Date expiry;
+
+    public AuthToken(String token, Date expiry) {
+        this.token = token;
+        this.expiry = expiry;
+    }
+}
+

--- a/src/main/java/com/harneet/ucal/physicianAssistantService/util/JwtUtil.java
+++ b/src/main/java/com/harneet/ucal/physicianAssistantService/util/JwtUtil.java
@@ -7,7 +7,6 @@ import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import org.springframework.stereotype.Component;
 
-
 import java.security.Key;
 import java.util.Date;
 import java.util.HashMap;
@@ -23,9 +22,10 @@ public class JwtUtil {
         secretKey = Keys.secretKeyFor(SignatureAlgorithm.HS256);
     }
 
-    public String generateToken(String username) {
+    public AuthToken generateToken(String username) {
         Map<String, Object> claims = new HashMap<>();
-        return createToken(claims, username);
+        String jwt = createToken(claims, username);
+        return new AuthToken(jwt, extractAllClaims(jwt).getExpiration());
     }
 
     private String createToken(Map<String, Object> claims, String subject) {


### PR DESCRIPTION
Let's change the response for the login request to JSON.

We ran into this error on the front-end. It's easier to handle, if the response is in JSON format.
![image](https://github.com/user-attachments/assets/71795771-54ba-4a0d-9ab5-8f45ef0e9686)

Also, it is a good idea to include the expiry in the response.
<img width="893" alt="Screenshot 2024-11-14 at 1 32 45 AM" src="https://github.com/user-attachments/assets/a8968711-dbe8-4550-b9ca-8d0e00a7e400">
